### PR TITLE
Open calendars by default #1

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -179,8 +179,8 @@ class Ctrl extends MetricsPanelCtrl {
       to: ''
     };
     this.datePickerShow = {
-      from: false,
-      to: false
+      from: true,
+      to: true
     };
     appEvents.emit('hide-modal');
   }

--- a/src/partials/modal.export.html
+++ b/src/partials/modal.export.html
@@ -16,9 +16,6 @@
         <div class="gf-form inline">
           <label class="gf-form-label width-4">From</label>
           <input type="text" class="gf-form-input input-large width-15" ng-model="ctrl.rangeOverride.from" input-datetime>
-          <button class="btn gf-form-btn btn-primary" type="button" ng-click="ctrl.datePickerShow.from = !ctrl.datePickerShow.from">
-            <i class="fa fa-calendar"></i>
-          </button>
         </div>
 
         <datepicker
@@ -36,9 +33,6 @@
         <div class="gf-form inline">
           <label class="gf-form-label width-4">To</label>
           <input type="text" class="gf-form-input input-large width-15" ng-model="ctrl.rangeOverride.to" input-datetime>
-          <button class="btn gf-form-btn btn-primary" type="button" ng-click="ctrl.datePickerShow.to = !ctrl.datePickerShow.to">
-            <i class="fa fa-calendar"></i>
-          </button>
         </div>
 
         <datepicker


### PR DESCRIPTION
closes https://github.com/CorpGlory/grafana-data-exporter-panel/issues/1

The calendars (datepicker) are now opened by default in Export window:

![image](https://user-images.githubusercontent.com/22073083/45824979-da4a9680-bcf9-11e8-82c9-6ddb3e1471cc.png)
