### PR TITLE
Allow various backend URL input #2

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -158,7 +158,15 @@ class Ctrl extends MetricsPanelCtrl {
 
     let user = await this._getCurrentUser();
 
-    this._backendSrv.post(`${this.panel.backendUrl}/tasks`, {
+    let formattedUrl = this.panel.backendUrl;
+    if (!this.panel.backendUrl.includes('http://')) {
+      formattedUrl = `http://${this.panel.backendUrl}`;
+    }
+    if (this.panel.backendUrl.slice(-1) === '/') {
+      formattedUrl = formattedUrl.slice(0, -1);
+    }
+
+    this._backendSrv.post(`${formattedUrl}/tasks`, {
       from: moment(this.rangeOverride.from).valueOf(),
       to: moment(this.rangeOverride.to).valueOf(),
       panelUrl,

--- a/src/module.ts
+++ b/src/module.ts
@@ -159,10 +159,10 @@ class Ctrl extends MetricsPanelCtrl {
     let user = await this._getCurrentUser();
 
     let formattedUrl = this.panel.backendUrl;
-    if (!this.panel.backendUrl.includes('http://')) {
+    if(!this.panel.backendUrl.includes('http://')) {
       formattedUrl = `http://${this.panel.backendUrl}`;
     }
-    if (this.panel.backendUrl.slice(-1) === '/') {
+    if(this.panel.backendUrl.slice(-1) === '/') {
       formattedUrl = formattedUrl.slice(0, -1);
     }
 

--- a/src/partials/editor.options.html
+++ b/src/partials/editor.options.html
@@ -7,7 +7,7 @@
         Backend URL
       </label>
 
-      <input type="url" class="gf-form-input width-18" data-placement="right" ng-model="ctrl.panel.backendUrl">
+      <input type="text" class="gf-form-input width-18" data-placement="right" ng-model="ctrl.panel.backendUrl">
     </div>
 
   </div>


### PR DESCRIPTION
closes https://github.com/CorpGlory/grafana-data-exporter-panel/issues/2

Backend URL field now supports inputs suchs as:
```http://localhost:8000```
```http://127.0.0.1:8000/```
```localhost:8000```
```127.0.0.1:8000/```
