### PR TITLE
Export window unresponsive size #8

### DIFF
--- a/src/css/panel.light.scss
+++ b/src/css/panel.light.scss
@@ -1,0 +1,3 @@
+.modal {
+  position: relative;
+}


### PR DESCRIPTION
closes https://github.com/CorpGlory/grafana-data-exporter-panel/issues/8

The size was not changed. Because if made responsive - the datepicker will become too hard to use.

Instead the whole export window is made scrollable -> possible to use on small screen.
![image](https://user-images.githubusercontent.com/22073083/46197803-77698880-c313-11e8-8929-c64dd1424702.png)
