### PR TITLE
Inherit from PanelCtrl instead of MetricPanelCtrl #16

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -37,7 +37,7 @@ class Ctrl extends PanelCtrl {
   private _datasourceRequest: any;
 
   static templateUrl = 'partials/module.html';
-  timeSrv: any;
+  private timeSrv: any;
   range: any;
 
   /** @ngInject */
@@ -52,7 +52,6 @@ class Ctrl extends PanelCtrl {
     this.events.on('init-edit-mode', this._onInitEditMode.bind(this));
 
     this.timeSrv = $injector.get('timeSrv');
-    this.range = this.timeSrv.timeRange();
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
@@ -114,6 +113,7 @@ class Ctrl extends PanelCtrl {
 
   private _onRender() {
     this._element.find('.table-panel-scroll').css({ 'max-height': this._getTableHeight() });
+    this.range = this.timeSrv.timeRange();
   }
 
   private _onInitEditMode() {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import './css/panel.base.scss';
 import './css/panel.dark.scss';
 import './css/panel.light.scss';
 
-import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';
+import { PanelCtrl } from 'grafana/app/plugins/sdk';
 import { appEvents } from 'grafana/app/core/core';
 
 import _ from 'lodash';
@@ -17,7 +17,7 @@ const PANEL_DEFAULTS = {
   backendUrl: ''
 }
 
-class Ctrl extends MetricsPanelCtrl {
+class Ctrl extends PanelCtrl {
   private _panelPath: string;
   private _partialsPath: string;
   public showRows: Object;
@@ -37,6 +37,8 @@ class Ctrl extends MetricsPanelCtrl {
   private _datasourceRequest: any;
 
   static templateUrl = 'partials/module.html';
+  timeSrv: any;
+  range: any;
 
   /** @ngInject */
   constructor($scope, $injector, private backendSrv, public templateSrv) {
@@ -48,6 +50,9 @@ class Ctrl extends MetricsPanelCtrl {
 
     this.events.on('render', this._onRender.bind(this));
     this.events.on('init-edit-mode', this._onInitEditMode.bind(this));
+
+    this.timeSrv = $injector.get('timeSrv');
+    this.range = this.timeSrv.timeRange();
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;

--- a/src/module.ts
+++ b/src/module.ts
@@ -38,7 +38,7 @@ class Ctrl extends PanelCtrl {
 
   static templateUrl = 'partials/module.html';
   private timeSrv: any;
-  range: any;
+  private range: any;
 
   /** @ngInject */
   constructor($scope, $injector, private backendSrv, public templateSrv) {


### PR DESCRIPTION
closes https://github.com/CorpGlory/grafana-data-exporter-panel/issues/16

No more metric tab:
![image](https://user-images.githubusercontent.com/22073083/46290259-01278900-c594-11e8-91ba-91c1cd246c03.png)
