### PR TITLE
MySQL / PostgreSQL support #33

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -60,8 +60,6 @@ class Ctrl extends PanelCtrl {
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
-      let datasourceId: string;
-      console.log(data);
 
       if(requestConfig.data !== undefined && requestConfig.data.queries !== undefined) {
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,9 +59,11 @@ class Ctrl extends PanelCtrl {
     this.timeSrv = $injector.get('timeSrv');
 
     appEvents.on('ds-request-response', data => {
-      let requestConfig = data.config;
+      const requestConfig = data.config;
+      const isSqlDatasource = requestConfig.data !== undefined &&
+        requestConfig.data.queries !== undefined;
 
-      if(requestConfig.data !== undefined && requestConfig.data.queries !== undefined) {
+      if(isSqlDatasource) {
 
         for(let query of requestConfig.data.queries) {
           this._datasourceRequests[query.datasourceId] = {
@@ -72,12 +74,12 @@ class Ctrl extends PanelCtrl {
           };
         }
       } else {
-        let datasourceIdRegExp = requestConfig.url.match(/proxy\/(\d+)/);
-        if(datasourceIdRegExp === null) {
+        let matched = requestConfig.url.match(/proxy\/(\d+)/);
+        if(matched === null) {
           throw new Error(`Cannot find datasource id in url ${requestConfig.url}`);
         }
 
-        let datasourceId = datasourceIdRegExp[1];
+        let datasourceId = matched[1];
 
         this._datasourceRequests[datasourceId] = {
           url: requestConfig.url,

--- a/src/module.ts
+++ b/src/module.ts
@@ -64,7 +64,6 @@ class Ctrl extends PanelCtrl {
         requestConfig.data.queries !== undefined;
 
       if(isSqlDatasource) {
-
         for(let query of requestConfig.data.queries) {
           this._datasourceRequests[query.datasourceId] = {
             url: query.url,
@@ -78,9 +77,7 @@ class Ctrl extends PanelCtrl {
         if(matched === null) {
           throw new Error(`Cannot find datasource id in url ${requestConfig.url}`);
         }
-
         let datasourceId = matched[1];
-
         this._datasourceRequests[datasourceId] = {
           url: requestConfig.url,
           method: requestConfig.method,

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,19 +60,34 @@ class Ctrl extends PanelCtrl {
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
-      let datasourceIdRegExp = requestConfig.url.match(/proxy\/(\d+)/);
-      if(datasourceIdRegExp === null) {
-        throw new Error(`Cannot find datasource id in url ${requestConfig.url}`);
+      let datasourceId: string;
+      console.log(data);
+
+      if(requestConfig.data !== undefined && requestConfig.data.queries !== undefined) {
+
+        for(let query of requestConfig.data.queries) {
+          this._datasourceRequests[query.datasourceId] = {
+            url: query.url,
+            method: query.method,
+            data: query.data,
+            params: query.params
+          };
+        }
+      } else {
+        let datasourceIdRegExp = requestConfig.url.match(/proxy\/(\d+)/);
+        if(datasourceIdRegExp === null) {
+          throw new Error(`Cannot find datasource id in url ${requestConfig.url}`);
+        }
+
+        let datasourceId = datasourceIdRegExp[1];
+
+        this._datasourceRequests[datasourceId] = {
+          url: requestConfig.url,
+          method: requestConfig.method,
+          data: requestConfig.data,
+          params: requestConfig.params
+        };
       }
-
-      let datasourceId = datasourceIdRegExp[1];
-
-      this._datasourceRequests[datasourceId] = {
-        url: requestConfig.url,
-        method: requestConfig.method,
-        data: requestConfig.data,
-        params: requestConfig.params
-      };
     });
 
     this.showRows = {};


### PR DESCRIPTION
## Problem
NoSQL datasources have `id` field in their `config.url` field.
SQL datasources don't have `id` field in `config.url`. All SQL queries are processed at `/api/tsdb` endpoint so datasource ID can be found only in response.

## Solution
In `ds-request-response` event callback we get datasource ID from `config.data.queries` field if it exists, otherwise ID is taken from `config.url`.

fixes #33 
fixes #32 

## Changes
- get `datasourceId` for SQL datasources from `config.data.queries` field
