### PR TITLE
Grafana 7: Exporter panel doesn't see datasource #40

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -122,6 +122,12 @@ class Ctrl extends PanelCtrl {
     }
   }
 
+  private async _getDefaultDatasource() {
+    const datasources = await this.backendSrv.get(`/api/datasources`);
+
+    return datasources.find(d => d.isDefault);
+  }
+
   private _initStyles() {
     (window as any).System.import(`${this._panelPath}/css/panel.base.css!`);
     if(grafanaBootData.user.lightTheme) {
@@ -175,12 +181,19 @@ class Ctrl extends PanelCtrl {
   private async _getGrafanaAPIInfo() {
     this._user = await this._getCurrentUser();
     for(let panel of this.panels) {
-      let datasourceName = panel.datasource;
-      if(!datasourceName) {
+      if (panel.type === 'corpglory-data-exporter-panel') {
         continue;
       }
-      let datasource = await this._getDatasourceByName(datasourceName);
-      this._datasourceTypes[panel.id] = datasource.type;
+
+      if (!panel.datasource) {
+        const datasource = await this._getDefaultDatasource();
+        panel.datasource = datasource?.name;
+
+        this._datasourceTypes[panel.id] = datasource?.type;
+      } else {
+        const datasource = await this._getDatasourceByName(panel.datasource);
+        this._datasourceTypes[panel.id] = datasource?.type
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes #40 
### Probem:
We don`t see default datasource in the exporter panel
### Solution:
Send an additional request to get all datasources and find one with the ```isDefault = true```
### Changes:
Added ```_getDefaultDatasource``` functon
Changaed ```_getGrafanaAPIInfo``` function
