### PR TITLE
Repair timerange pickers in grafana 6 and 7 #41

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -24,7 +24,8 @@ module.exports = {
   },
   externals: [
     // remove the line below if you don't want to use buildin versions
-    'jquery', 'lodash', 'moment',
+    'jquery', 'lodash', 'moment', 'react', 'react-dom',
+    '@grafana/ui', '@grafana/data', '@grafana/runtime',
     function (context, request, callback) {
       var prefix = 'grafana/';
       if (request.indexOf(prefix) === 0) {
@@ -49,12 +50,13 @@ module.exports = {
   resolve: {
     alias: {
       'src': resolve('src')
-    }
+    },
+    extensions: ['.js', '.ts', '.tsx']
   },
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.tsx?$/,
         exclude: /node_modules/,
         use: {
           loader: 'ts-loader'

--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -17,6 +17,9 @@ panel-plugin-export-manager-panel {
 
 .modal {
   position: relative;
+  .editor-row {
+    text-align: center;
+  }
   .timepicker {
     .navbar-button--zoom {
       display: none;

--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -17,4 +17,14 @@ panel-plugin-export-manager-panel {
 
 .modal {
   position: relative;
+  .timepicker {
+    .navbar-button--zoom {
+      display: none;
+    }
+    > div > div {
+      &>.navbar-button--tight {
+        display: none;
+      }
+    }
+  }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import './css/panel.base.scss';
 import './css/panel.dark.scss';
 import './css/panel.light.scss';
 
-import './timepicker.ts';
+import './timepicker';
 
 import { PanelCtrl } from 'grafana/app/plugins/sdk';
 import { appEvents } from 'grafana/app/core/core';

--- a/src/module.ts
+++ b/src/module.ts
@@ -211,7 +211,7 @@ class Ctrl extends PanelCtrl {
     this._datasourceRequests[datasourceId].type = this._datasourceTypes[panelId];
 
     let formattedUrl = this.templateSrv.replace(this.panel.backendUrl);
-    if(!formattedUrl.includes('http://') || !formattedUrl.includes('https://')) {
+    if(!formattedUrl.includes('http://') && !formattedUrl.includes('https://')) {
       formattedUrl = `http://${formattedUrl}`;
     }
     if(formattedUrl.slice(-1) === '/') {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,8 @@ import './css/panel.base.scss';
 import './css/panel.dark.scss';
 import './css/panel.light.scss';
 
+import './timepicker.ts';
+
 import { PanelCtrl } from 'grafana/app/plugins/sdk';
 import { appEvents } from 'grafana/app/core/core';
 
@@ -9,9 +11,6 @@ import _ from 'lodash';
 import $ from 'jquery';
 import moment from 'moment';
 
-
-// TODO: add to types-grafana
-declare var grafanaBootData: any;
 
 const PANEL_DEFAULTS = {
   backendUrl: ''
@@ -22,13 +21,13 @@ class Ctrl extends PanelCtrl {
   private _partialsPath: string;
   public showRows: Object;
   private _element;
-  public rangeOverride: {
-    from: string,
-    to: string
-  };
-  public rangeOverrideRaw: {
-    from: string,
-    to: string
+  public rangeOverride = {
+    from: moment(),
+    to: moment(),
+    raw: {
+      from: moment(),
+      to: moment()
+    }
   };
   public datePickerShow: {
     from: Boolean,
@@ -123,11 +122,11 @@ class Ctrl extends PanelCtrl {
   }
 
   private _initStyles() {
-    (window as any).System.import(`${this._panelPath}/css/panel.base.css!`);
-    if(grafanaBootData.user.lightTheme) {
-      (window as any).System.import(`${this._panelPath}/css/panel.light.css!`);
+    window.System.import(`${this._panelPath}/css/panel.base.css!`);
+    if(window.grafanaBootData.user.lightTheme) {
+      window.System.import(`${this._panelPath}/css/panel.light.css!`);
     } else {
-      (window as any).System.import(`${this._panelPath}/css/panel.dark.css!`);
+      window.System.import(`${this._panelPath}/css/panel.dark.css!`);
     }
   }
 
@@ -189,12 +188,8 @@ class Ctrl extends PanelCtrl {
     this.render();
   }
 
-  onRangeFromChange() {
-    this.rangeOverride.from = moment(this.rangeOverrideRaw.from).format();
-  }
-
-  onRangeToChange() {
-    this.rangeOverride.to = moment(this.rangeOverrideRaw.to).format();
+  onRangeFromChange(timeRange: any) {
+    this.rangeOverride = timeRange;
   }
 
   async export(panelId, target) {
@@ -219,8 +214,8 @@ class Ctrl extends PanelCtrl {
     }
 
     this.backendSrv.post(`${formattedUrl}/tasks`, {
-      from: moment(this.rangeOverride.from).valueOf(),
-      to: moment(this.rangeOverride.to).valueOf(),
+      from: this.rangeOverride.from.valueOf(),
+      to: this.rangeOverride.to.valueOf(),
       panelUrl,
       target,
       datasourceRequest: this._datasourceRequests[datasourceId],
@@ -251,12 +246,12 @@ class Ctrl extends PanelCtrl {
 
   clearRange() {
     this.rangeOverride = {
-      from: this.range.from.toISOString(),
-      to: this.range.to.toISOString()
-    };
-    this.rangeOverrideRaw = {
-      from: this.range.from.toISOString(),
-      to: this.range.to.toISOString()
+      from: this.range.from,
+      to: this.range.to,
+      raw: {
+        from: this.range.from,
+        to: this.range.to
+      }
     };
     this.datePickerShow = {
       from: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,10 +18,10 @@ const PANEL_DEFAULTS = {
 
 type TimeRange = {
   from: moment.Moment,
-    to: moment.Moment,
-      raw: {
+  to: moment.Moment,
+  raw: {
     from: moment.Moment,
-      to: moment.Moment
+    to: moment.Moment
   }
 };
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,12 +16,21 @@ const PANEL_DEFAULTS = {
   backendUrl: ''
 }
 
+type TimeRange = {
+  from: moment.Moment,
+    to: moment.Moment,
+      raw: {
+    from: moment.Moment,
+      to: moment.Moment
+  }
+};
+
 class Ctrl extends PanelCtrl {
   private _panelPath: string;
   private _partialsPath: string;
   public showRows: Object;
   private _element;
-  public rangeOverride = {
+  public rangeOverride: TimeRange = {
     from: moment(),
     to: moment(),
     raw: {
@@ -188,7 +197,7 @@ class Ctrl extends PanelCtrl {
     this.render();
   }
 
-  onRangeFromChange(timeRange: any) {
+  onTimeRangeChange(timeRange: TimeRange): void {
     this.rangeOverride = timeRange;
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -211,7 +211,7 @@ class Ctrl extends PanelCtrl {
     this._datasourceRequests[datasourceId].type = this._datasourceTypes[panelId];
 
     let formattedUrl = this.templateSrv.replace(this.panel.backendUrl);
-    if(!formattedUrl.includes('http://')) {
+    if(!formattedUrl.includes('http://') || !formattedUrl.includes('https://')) {
       formattedUrl = `http://${formattedUrl}`;
     }
     if(formattedUrl.slice(-1) === '/') {

--- a/src/partials/modal.export.html
+++ b/src/partials/modal.export.html
@@ -17,7 +17,7 @@
           ng-if="ctrl.datePickerShow.from"
           class="timepicker"
           value="ctrl.rangeOverride"
-          onChange="ctrl.onRangeFromChange.bind(ctrl)"
+          onChange="ctrl.onTimeRangeChange.bind(ctrl)"
         />
       </div>
     </div>

--- a/src/partials/modal.export.html
+++ b/src/partials/modal.export.html
@@ -13,37 +13,12 @@
   <div class="modal-content">
     <div class="editor-row">
       <div class="section gf-form-group">
-        <div class="gf-form inline">
-          <label class="gf-form-label width-4">From</label>
-          <input type="text" class="gf-form-input input-large width-15" ng-model="ctrl.rangeOverride.from" input-datetime>
-        </div>
-
-        <datepicker
+        <timepicker
           ng-if="ctrl.datePickerShow.from"
-          ng-model="ctrl.rangeOverrideRaw.from"
-          class="gf-timepicker-component"
-          show-weeks="false"
-          starting-day="1"
-          ng-change="ctrl.onRangeFromChange()"
-        >
-        </datepicker>
-      </div>
-
-      <div class="section gf-form-group">
-        <div class="gf-form inline">
-          <label class="gf-form-label width-4">To</label>
-          <input type="text" class="gf-form-input input-large width-15" ng-model="ctrl.rangeOverride.to" input-datetime>
-        </div>
-
-        <datepicker
-          ng-if="ctrl.datePickerShow.to"
-          ng-model="ctrl.rangeOverrideRaw.to"
-          class="gf-timepicker-component"
-          show-weeks="false"
-          starting-day="1"
-          ng-change="ctrl.onRangeToChange()"
-        >
-        </datepicker>
+          class="timepicker"
+          value="ctrl.rangeOverride"
+          onChange="ctrl.onRangeFromChange.bind(ctrl)"
+        />
       </div>
     </div>
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -16,10 +16,10 @@
     "links": [],
     "screenshots": [],
     "version": "0.3.6",
-    "updated": "2020-01-21"
+    "updated": "2020-09-22"
   },
   "dependencies": {
-    "grafanaVersion": "4.6.x 5.x",
+    "grafanaVersion": "6.2.0+",
     "plugins": []
   }
 }

--- a/src/react2angular/ConfigProvider.tsx
+++ b/src/react2angular/ConfigProvider.tsx
@@ -1,0 +1,40 @@
+// this file is copied from Grafana 6.7.x
+// public/app/core/utils/ConfigProvider.tsx
+
+// we can't enable ts checks here because we use @grafana/* libs as externals
+// @ts-nocheck
+
+import React from 'react';
+import { config, GrafanaBootConfig } from '@grafana/runtime';
+import { ThemeContext, getTheme } from '@grafana/ui';
+import { GrafanaThemeType } from '@grafana/data';
+
+export const ConfigContext = React.createContext<GrafanaBootConfig>(config);
+export const ConfigConsumer = ConfigContext.Consumer;
+
+export const provideConfig = (component: React.ComponentType<any>) => {
+  const ConfigProvider = (props: any) => (
+    <ConfigContext.Provider value={config}>{React.createElement(component, { ...props })}</ConfigContext.Provider>
+  );
+
+  return ConfigProvider;
+};
+
+export const getCurrentThemeName = () =>
+  config.bootData.user.lightTheme ? GrafanaThemeType.Light : GrafanaThemeType.Dark;
+
+export const getCurrentTheme = () => getTheme(getCurrentThemeName());
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <ConfigConsumer>
+      {config => {
+        return <ThemeContext.Provider value={getCurrentTheme()}>{children}</ThemeContext.Provider>;
+      }}
+    </ConfigConsumer>
+  );
+};
+
+export const provideTheme = (component: React.ComponentType<any>) => {
+  return provideConfig((props: any) => <ThemeProvider>{React.createElement(component, { ...props })}</ThemeProvider>);
+};

--- a/src/react2angular/index.ts
+++ b/src/react2angular/index.ts
@@ -1,0 +1,14 @@
+// this file is copied from Grafana 6.7.x
+// public/app/core/utils/react2angular.ts
+
+import { coreModule } from 'grafana/app/core/core';
+import { provideTheme } from './ConfigProvider';
+
+export function react2AngularDirective(name: string, component: any, options: any) {
+  coreModule.directive(name, [
+    'reactDirective',
+    reactDirective => {
+      return reactDirective(provideTheme(component), options);
+    },
+  ]);
+}

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -1,0 +1,15 @@
+import { react2AngularDirective } from './react2angular';
+
+// it's TimePicker since Grafana 6.2.0 and TimeRangePicker since Grafana 7.0
+// @ts-ignore
+import { TimePicker, TimeRangePicker } from '@grafana/ui';
+
+const timePicker = TimePicker || TimeRangePicker;
+react2AngularDirective('timepicker', timePicker, [
+  // TODO: there are more props
+  'value',
+  'onChange',
+  'onMoveBackward',
+  'onMoveForward',
+  'onZoom'
+]);

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -4,6 +4,7 @@ import { react2AngularDirective } from './react2angular';
 // @ts-ignore
 import { TimePicker, TimeRangePicker } from '@grafana/ui';
 
+// we don't know which one we'll use so we import both and pick the one that is not undefined
 const timePicker = TimePicker || TimeRangePicker;
 react2AngularDirective('timepicker', timePicker, [
   // TODO: there are more props


### PR DESCRIPTION
Closes #41 

This PR makes calendars work in Grafana 6 and 7

> Note: it breaks compatibility with Grafana < 6.2.0

## Before
![image](https://user-images.githubusercontent.com/47055832/88178959-d52b3b00-cc33-11ea-9868-ea3fd13afb8f.png)

## After (Grafana 6.6.1)
![image](https://user-images.githubusercontent.com/1989898/93893813-bd853700-fcf6-11ea-8a3f-012d2f158f3b.png)

## After (Grafana 7.1.5)
![image](https://user-images.githubusercontent.com/1989898/93893869-cb3abc80-fcf6-11ea-9bf7-28a08b6ddd7e.png)

## Problem
`datepicker` directive which were used to render calendars was removed from Grafana in some 6.x version (don't know which one exactly)

## Changes
- use `TimePicker` (Grafana 6.x) or `TimeRangePicker` (Grafana 7.x) React component to render timerange picker
- copy `react2angular` function from Grafana to convert it the component to Angular directive

## Other changes
- fix `window` usage (`window as any` -> `window`), it's possible after `@types/grafana` changes
- change supported Grafana versions in `plugin.json`