### PR TITLE
Confusing UI regards data-exporter service #51

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -221,19 +221,19 @@ class Ctrl extends PanelCtrl {
   private async _getDatasourceRequest(name: string): Promise<DatasourceRequest> {
     const datasource = await this._getDatasourceByName(name);
     const datasourceId = datasource.id;
-    const datasourceRequest = this._datasourceRequests[datasourceId];
 
     if(datasource.access !== 'proxy') {
       throw new Error(`"${datasource.name}" datasource has "Browser" access type but only "Server" is supported`);
     }
 
+    const datasourceRequest = this._datasourceRequests[datasourceId];
     if(datasourceRequest === undefined) {
       throw new Error('Datasource is not set. If it`s Grafana-test-datasource then it`s not supported');
     }
+
     if(datasourceRequest.type === undefined || datasourceRequest.type === null) {
       datasourceRequest.type = datasource.type
     }
-
     if(datasourceRequest.datasourceId === undefined) {
       datasourceRequest.datasourceId = datasourceId;
     }
@@ -281,14 +281,14 @@ class Ctrl extends PanelCtrl {
         datasourceName,
         user: this._user
       });
-    
+
       appEvents.emit('alert-success', ['Task added', resp]);
       appEvents.emit('hide-modal');
       this.clearRange();
       this.timeSrv.refreshDashboard();
     } catch(err) {
       appEvents.emit('alert-error', [
-        `Error while adding task at ${err.config.url}`, 
+        `Error while adding task at ${err.config.url}`,
         err.statusText !== '' ? err.statusText : 'grafana-data-exporter is not available'
       ]);
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -220,6 +220,11 @@ class Ctrl extends PanelCtrl {
 
   private async _getDatasourceRequest(name: string): Promise<DatasourceRequest> {
     const datasource = await this._getDatasourceByName(name);
+
+    if(datasource === undefined) {
+      throw new Error(`Can't get info about "${name}" datasource`);
+    }
+
     const datasourceId = datasource.id;
 
     if(datasource.access !== 'proxy') {

--- a/src/module.ts
+++ b/src/module.ts
@@ -232,7 +232,7 @@ class Ctrl extends PanelCtrl {
     }
 
     if(datasourceRequest.type === undefined || datasourceRequest.type === null) {
-      datasourceRequest.type = datasource.type
+      datasourceRequest.type = datasource.type;
     }
     if(datasourceRequest.datasourceId === undefined) {
       datasourceRequest.datasourceId = datasourceId;

--- a/src/module.ts
+++ b/src/module.ts
@@ -247,8 +247,8 @@ class Ctrl extends PanelCtrl {
 
     let panel = this.panels.find(el => el.id === panelId);
     let datasourceName = panel.datasource;
-    let datasourceRequest = null;
 
+    let datasourceRequest;
     try {
       datasourceRequest = await this._getDatasourceRequest(datasourceName);
     } catch (e) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,13 +4,14 @@ import './css/panel.light.scss';
 
 import './timepicker';
 
+import { DatasourceRequest } from './models/datasource';
+
 import { PanelCtrl } from 'grafana/app/plugins/sdk';
 import { appEvents } from 'grafana/app/core/core';
 
 import _ from 'lodash';
 import $ from 'jquery';
 import moment from 'moment';
-import { DatasourceRequest } from 'models/datasource';
 
 
 const PANEL_DEFAULTS = {

--- a/src/module.ts
+++ b/src/module.ts
@@ -287,7 +287,6 @@ class Ctrl extends PanelCtrl {
       this.clearRange();
       this.timeSrv.refreshDashboard();
     } catch(err) {
-      console.log(JSON.stringify(err))
       appEvents.emit('alert-error', [
         `Error while adding task at ${err.config.url}`, 
         err.statusText !== '' ? err.statusText : 'grafana-data-exporter is not available'


### PR DESCRIPTION
This PR improves error handling for cases when:
- grafana-data-exporter is not available
- datasource access type is "Browser", not "Server"

Changes:
- display errors on "Browser" datasources and Grafana-test-datasource export
- display `grafana-data-exporter is not available` alert when grafana-data-exporter is not available

Other changes:
- `console.error` instead of `throw` when datasource is "Browser" type (it fixes panels with "Browser" datasource)