### PR TITLE
missing panel in list fix #49

### DIFF
--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -36,3 +36,7 @@ panel-plugin-export-manager-panel {
   opacity: 50%;
   pointer-events: none;
 }
+
+.export-button-td {
+  display: inline-block;
+}

--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -31,3 +31,8 @@ panel-plugin-export-manager-panel {
     }
   }
 }
+
+.disabled-button {
+  opacity: 50%;
+  pointer-events: none;
+}

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -36,11 +36,12 @@
           <td>
             {{ ctrl.getDatasource(panel) }}
           </td>
-          <td style="display: inline-block" bs-tooltip="!panel.datasource ? 'Datasource is not supported' : null">
+          <td class="export-button-td" bs-tooltip="panel.datasource === undefined ? 'Datasource is not supported' : null">
             <button class="btn gf-form-btn btn-primary"
-              ng-class="{'disabled-button': !panel.datasource}"
+              ng-class="{'disabled-button': panel.datasource === undefined}"
               type="button"
-              ng-click="ctrl.showExportModal(panel.id, target)">
+              ng-click="ctrl.showExportModal(panel.id, target)"
+            >
               <div>Export</div>
             </button>
           </td>

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -24,7 +24,7 @@
       </thead>
       <tbody>
         <tr ng-repeat-start="panel in ctrl.panels"></tr>
-        <tr class="target" ng-repeat-end ng-repeat="target in panel.targets" ng-if="panel.datasource">
+        <tr class="target" ng-repeat-end ng-repeat="target in panel.targets" ng-if="panel.type !== 'corpglory-data-exporter-panel'">
           <td>
             {{ panel.title }}
           </td>
@@ -36,10 +36,13 @@
           <td>
             {{ ctrl.getDatasource(panel) }}
           </td>
-          <td>
-            <button class="btn gf-form-btn btn-primary" type="button" ng-click="ctrl.showExportModal(panel.id, target)">
-              Export
-            </button>
+          <td style="display: inline-block" bs-tooltip="!panel.datasource ? 'Datasource is not supported' : null">
+              <button class="btn gf-form-btn btn-primary"
+                      ng-class="{'disabled-button': !panel.datasource}"
+                      type="button"
+                      ng-click="ctrl.showExportModal(panel.id, target)">
+                <div>Export</div>
+              </button>
           </td>
         </tr>
       </tbody>

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -37,12 +37,12 @@
             {{ ctrl.getDatasource(panel) }}
           </td>
           <td style="display: inline-block" bs-tooltip="!panel.datasource ? 'Datasource is not supported' : null">
-              <button class="btn gf-form-btn btn-primary"
-                      ng-class="{'disabled-button': !panel.datasource}"
-                      type="button"
-                      ng-click="ctrl.showExportModal(panel.id, target)">
-                <div>Export</div>
-              </button>
+            <button class="btn gf-form-btn btn-primary"
+              ng-class="{'disabled-button': !panel.datasource}"
+              type="button"
+              ng-click="ctrl.showExportModal(panel.id, target)">
+              <div>Export</div>
+            </button>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
The exporter doesn't display panels with datasources that it does not support. This PR makes the exporter display them with disabled Export button  

**Problem**  
Exporter panel does not display panels without ```panel.datasource```  

**Solution**  
Display every panel in the exporter, except for the exporter itself, but disable the "export" button.  
Also, show tooltip on button hover.  

