### PR TITLE
Add single button for export all panels

### DIFF
--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -40,3 +40,8 @@ panel-plugin-export-manager-panel {
 .export-button-td {
   display: inline-block;
 }
+
+#export-button {
+  display: block;
+  margin: 0 auto;
+}

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -1,0 +1,1 @@
+type TDictionary<TKey extends number | string, TValue> = TKey extends number ? {[key: number]: TValue} : {[key: string]: TValue};

--- a/src/models/datasource.ts
+++ b/src/models/datasource.ts
@@ -2,6 +2,7 @@ export type DatasourceRequest = {
   method: string,
   data: Object,
   params: Object,
-  type: string,
-  url: string
+  type?: string,
+  url: string,
+  datasourceId?: number
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -246,6 +246,10 @@ class Ctrl extends PanelCtrl {
     return datasourceRequest;
   }
 
+  /**
+   * Create task for export data from panels
+   * @param panelId Panel ID, if null, then export data from all panels
+   */
   async export(panelId: string | null, target: any): Promise<void> {
 
     const exportPanels = this.panels.filter(panel =>
@@ -254,14 +258,14 @@ class Ctrl extends PanelCtrl {
       (panelId === null || panel.id === panelId)
     );
 
-    let datasources = {};
+    let datasourceTable = {};
     try {
-      datasources = await this.backendSrv.get(`/api/datasources`) ;
+      let datasources = await this.backendSrv.get(`/api/datasources`) ;
 
       const exportTable = _.keyBy(exportPanels, 'datasource');
-      datasources = (datasources as {name: string}[])
+      datasourceTable = (datasources as {name: string}[])
         .reduce((result, item) => {
-        if (exportTable[item.name]) {
+        if(exportTable[item.name]) {
           result[item.name] = this._formatDatasourceRequest(item);
         }
         return result;
@@ -281,7 +285,7 @@ class Ctrl extends PanelCtrl {
     // TODO: support org_id
     const data = exportPanels.map(panel => ({
       panelUrl: window.location.origin + window.location.pathname + `?panelId=${panel.id}&fullscreen`,
-      datasourceRequest: datasources[panel.datasource],
+      datasourceRequest: datasourceTable[panel.datasource],
       datasourceName: panel.datasource
     }));
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,10 +28,12 @@ type TimeRange = {
 };
 
 class Ctrl extends PanelCtrl {
+  private readonly selfType = 'corpglory-data-exporter-panel';
+
   private _panelPath: string;
   private _partialsPath: string;
-  public showRows: Object;
-  private _element;
+  public showRows: TDictionary<number, boolean>;
+  private _element: JQuery;
   public rangeOverride: TimeRange = {
     from: moment(),
     to: moment(),
@@ -44,8 +46,8 @@ class Ctrl extends PanelCtrl {
     from: Boolean,
     to: Boolean
   };
-  private _datasourceRequests: any;
-  private _datasourceTypes: any;
+  private _datasourceRequests: TDictionary<number, DatasourceRequest>;
+  private _datasourceTypes: TDictionary<number, string>;
   private _datasources: any;
   private _user: string;
 
@@ -107,7 +109,7 @@ class Ctrl extends PanelCtrl {
     });
   }
 
-  link(scope, element) {
+  link(scope, element: JQuery) {
     this._element = element;
     this._initStyles();
 
@@ -165,7 +167,7 @@ class Ctrl extends PanelCtrl {
     return this.height - 31 + 'px';
   }
 
-  showExportModal(panelId, target) {
+  showExportModal(panelId: number | null, target) {
     this.clearRange();
     let modalScope = this.$scope.$new(true);
     modalScope.ctrl = this;
@@ -193,7 +195,7 @@ class Ctrl extends PanelCtrl {
   private async _getGrafanaAPIInfo() {
     this._user = await this._getCurrentUser();
     for(let panel of this.panels) {
-      if(panel.type === 'corpglory-data-exporter-panel' || panel.datasource === undefined) {
+      if(panel.type === this.selfType || panel.datasource === undefined) {
         continue;
       }
 
@@ -218,14 +220,12 @@ class Ctrl extends PanelCtrl {
     this.rangeOverride = timeRange;
   }
 
-  private async _getDatasourceRequest(name: string): Promise<DatasourceRequest> {
-    const datasource = await this._getDatasourceByName(name);
-
+  private _formatDatasourceRequest(datasource: any): DatasourceRequest {
     if(datasource === undefined) {
       throw new Error(`Can't get info about "${name}" datasource`);
     }
 
-    const datasourceId = datasource.id;
+    const datasourceId: number = datasource.id;
 
     if(datasource.access !== 'proxy') {
       throw new Error(`"${datasource.name}" datasource has "Browser" access type but only "Server" is supported`);
@@ -246,16 +246,26 @@ class Ctrl extends PanelCtrl {
     return datasourceRequest;
   }
 
-  async export(panelId: string, target: any): Promise<void> {
-    // TODO: support org_id
-    let panelUrl = window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`;
+  async export(panelId: string | null, target: any): Promise<void> {
 
-    let panel = this.panels.find(el => el.id === panelId);
-    let datasourceName = panel.datasource;
+    const exportPanels = this.panels.filter(panel =>
+      panel.datasource !== undefined &&
+      panel.type !== this.selfType &&
+      (panelId === null || panel.id === panelId)
+    );
 
-    let datasourceRequest;
+    let datasources = {};
     try {
-      datasourceRequest = await this._getDatasourceRequest(datasourceName);
+      datasources = await this.backendSrv.get(`/api/datasources`) ;
+
+      const exportTable = _.keyBy(exportPanels, 'datasource');
+      datasources = (datasources as {name: string}[])
+        .reduce((result, item) => {
+        if (exportTable[item.name]) {
+          result[item.name] = this._formatDatasourceRequest(item);
+        }
+        return result;
+      });
     } catch (e) {
       appEvents.emit(
         'alert-error',
@@ -267,6 +277,13 @@ class Ctrl extends PanelCtrl {
 
       return;
     }
+
+    // TODO: support org_id
+    const data = exportPanels.map(panel => ({
+      panelUrl: window.location.origin + window.location.pathname + `?panelId=${panel.id}&fullscreen`,
+      datasourceRequest: datasources[panel.datasource],
+      datasourceName: panel.datasource
+    }));
 
     let formattedUrl = this.templateSrv.replace(this.panel.backendUrl);
     if(!formattedUrl.includes('http://') && !formattedUrl.includes('https://')) {
@@ -280,10 +297,8 @@ class Ctrl extends PanelCtrl {
       const resp = await this.backendSrv.post(`${formattedUrl}/tasks`, {
         from: this.rangeOverride.from.valueOf(),
         to: this.rangeOverride.to.valueOf(),
-        panelUrl,
+        data,
         target,
-        datasourceRequest,
-        datasourceName,
         user: this._user
       });
 

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -24,7 +24,7 @@
       </thead>
       <tbody>
         <tr ng-repeat-start="panel in ctrl.panels"></tr>
-        <tr class="target" ng-repeat-end ng-repeat="target in panel.targets" ng-if="panel.type !== 'corpglory-data-exporter-panel'">
+        <tr class="target" ng-repeat-end ng-repeat="target in panel.targets" ng-if="panel.type !== selfType">
           <td>
             {{ panel.title }}
           </td>
@@ -48,5 +48,13 @@
         </tr>
       </tbody>
     </table>
+    <button class="btn gf-form-btn btn-primary"
+      id="export-button"
+      ng-if="!!ctrl.panels.length"
+      type="button"
+      ng-click="ctrl.showExportModal(null, target)"
+    >
+      <div>Export all</div>
+    </button>
   </div>
 </div>

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -50,7 +50,7 @@
     </table>
     <button class="btn gf-form-btn btn-primary"
       id="export-button"
-      ng-if="!!ctrl.panels.length"
+      ng-if="ctrl.panels.length > 0"
       type="button"
       ng-click="ctrl.showExportModal(null, target)"
     >


### PR DESCRIPTION
Added button for export all from export panel https://github.com/CorpGlory/grafana-data-exporter-panel/issues/42  
When you click the "Export all" button a task is created for each exported panel  

**Changes**  
Send many panels to the exporter, instead of one, as it was before  
Small types refactoring
![image](https://user-images.githubusercontent.com/9702472/94876440-b71a5c00-0468-11eb-874c-e4abdfd5f511.png)
